### PR TITLE
yarn-operator: support multi yarn cluster

### DIFF
--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -45,7 +45,49 @@ data:
         <property>
             <name>yarn.resourcemanager.address.rm3</name>
             <value>0.0.0.0:8032</value>
+        </property>
     </configuration>
-  core-site.xml: |
+  # format: ${cluster-id}.yarn-site.xml
+  clusterid.yarn-site.xml: |
     <configuration>
+        <property>
+            <name>yarn.resourcemanager.admin.address</name>
+            <value>0.0.0.0:8033</value>
+        </property>
+        <property>
+            <name>yarn.resourcemanager.address</name>
+            <value>0.0.0.0:8032</value>
+        </property>
+        <property>
+          <name>yarn.resourcemanager.ha.enabled</name>
+          <value>true</value>
+        </property>
+        <property>
+            <name>yarn.resourcemanager.ha.rm-ids</name>
+            <value>rm1,rm2,rm3</value>
+        </property>
+        <property>
+            <name>yarn.resourcemanager.admin.address.rm1</name>
+            <value>0.0.0.0:8033</value>
+        </property>
+        <property>
+            <name>yarn.resourcemanager.admin.address.rm2</name>
+            <value>0.0.0.0:8033</value>
+        </property>
+        <property>
+            <name>yarn.resourcemanager.admin.address.rm3</name>
+            <value>0.0.0.0:8033</value>
+        </property>
+        <property>
+            <name>yarn.resourcemanager.address.rm1</name>
+            <value>0.0.0.0:8032</value>
+        </property>
+        <property>
+            <name>yarn.resourcemanager.address.rm2</name>
+            <value>0.0.0.0:8032</value>
+        </property>
+        <property>
+            <name>yarn.resourcemanager.address.rm3</name>
+            <value>0.0.0.0:8032</value>
+        </property>
     </configuration>

--- a/config/manager/yarn-operator.yaml
+++ b/config/manager/yarn-operator.yaml
@@ -57,7 +57,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: HADOOP_CONF_DIR
               value: /etc/hadoop-conf
-          image: registry.cn-beijing.aliyuncs.com/koordinator-sh/yarn-operator:fix-rpc-8843dea
+          image: registry.cn-beijing.aliyuncs.com/koordinator-sh/yarn-operator:multi-cluster-a4372e4
           imagePullPolicy: Always
           name: yarn-operator
           ports:

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 require (
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-resty/resty/v2 v2.7.0
+	github.com/golangplus/testing v1.0.0
 	github.com/opencontainers/runc v1.0.2
 )
 
@@ -110,6 +111,7 @@ require (
 	github.com/goccy/go-json v0.9.7 // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
+	github.com/golangplus/bytes v1.0.0 // indirect
 	github.com/google/cadvisor v0.39.3 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hodgesds/perf-utils v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -586,7 +586,14 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450/go.mod h1:Bk6SMAONeMXrxql8uvOKuAZSu8aM5RUGv+1C6IJaEho=
+github.com/golangplus/bytes v1.0.0 h1:YQKBijBVMsBxIiXT4IEhlKR2zHohjEqPole4umyDX+c=
+github.com/golangplus/bytes v1.0.0/go.mod h1:AdRaCFwmc/00ZzELMWb01soso6W1R/++O1XL80yAn+A=
+github.com/golangplus/fmt v1.0.0 h1:FnUKtw86lXIPfBMc3FimNF3+ABcV+aH5F17OOitTN+E=
+github.com/golangplus/fmt v1.0.0/go.mod h1:zpM0OfbMCjPtd2qkTD/jX2MgiFCqklhSUFyDW44gVQE=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
+github.com/golangplus/testing v1.0.0 h1:+ZeeiKZENNOMkTTELoSySazi+XaEhVO0mb+eanrSEUQ=
+github.com/golangplus/testing v1.0.0/go.mod h1:ZDreixUV3YzhoVraIDyOzHrr76p6NUh6k/pPg/Q3gYA=
 github.com/gomarkdown/markdown v0.0.0-20200824053859-8c8b3816f167/go.mod h1:aii0r/K0ZnHv7G0KF7xy1v0A7s2Ljrb5byB7MO5p6TU=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/pkg/controller/noderesource/resource_sync_controller_test.go
+++ b/pkg/controller/noderesource/resource_sync_controller_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderesource
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/golangplus/testing/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestYARNResourceSyncReconciler_getYARNNode(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	type fields struct {
+		pods *corev1.Pod
+	}
+	type args struct {
+		node *corev1.Node
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *yarnNode
+		wantErr bool
+	}{
+		{
+			name: "default yarn node",
+			fields: fields{
+				pods: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-manager",
+						Labels: map[string]string{
+							yarnNMComponentLabel: yarnNMComponentValue,
+						},
+						Annotations: map[string]string{
+							yarnNodeIdAnnotation:    "test-nm-id:8041",
+							yarnClusterIDAnnotation: "test-cluster-id",
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "test-node-name",
+					},
+				},
+			},
+			args: args{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node-name",
+					},
+				},
+			},
+			want: &yarnNode{
+				Name:      "test-nm-id",
+				Port:      8041,
+				ClusterID: "test-cluster-id",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &YARNResourceSyncReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+			}
+			if tt.fields.pods != nil {
+				err := r.Client.Create(context.Background(), tt.fields.pods)
+				assert.NoError(t, err)
+			}
+
+			got, err := r.getYARNNode(tt.args.node)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getYARNNode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getYARNNode() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/noderesource/yarn_node.go
+++ b/pkg/controller/noderesource/yarn_node.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderesource
+
+const (
+	yarnNMComponentLabel    = "app.kubernetes.io/component"
+	yarnNMComponentValue    = "node-manager"
+	yarnNodeIdAnnotation    = "yarn.hadoop.apache.org/node-id"
+	yarnClusterIDAnnotation = "yarn.hadoop.apache.org/cluster-id"
+)
+
+type yarnNode struct {
+	Name      string
+	Port      int32
+	ClusterID string
+}

--- a/pkg/yarn/client/examples/ha-get-service-status/main.go
+++ b/pkg/yarn/client/examples/ha-get-service-status/main.go
@@ -27,7 +27,7 @@ import (
 
 func main() {
 	// Create YarnConfiguration
-	conf, err := yarnconf.NewYarnConfiguration(os.Getenv("HADOOP_CONF_DIR"))
+	conf, err := yarnconf.NewYarnConfiguration(os.Getenv("HADOOP_CONF_DIR"), "")
 	if err != nil {
 		log.Fatal("new yarn conf", err)
 	}

--- a/pkg/yarn/client/examples/rm-get-cluster-nodes-with-ha/main.go
+++ b/pkg/yarn/client/examples/rm-get-cluster-nodes-with-ha/main.go
@@ -26,7 +26,6 @@ import (
 func main() {
 	// Create YarnClient
 	yarnClient, _ := yarnclient.CreateYarnClient()
-	yarnClient.Initialize()
 
 	request := &hadoopyarn.GetClusterNodesRequestProto{
 		NodeStates: []hadoopyarn.NodeStateProto{},

--- a/pkg/yarn/client/examples/rm-update-node-resource-with-ha/main.go
+++ b/pkg/yarn/client/examples/rm-update-node-resource-with-ha/main.go
@@ -27,7 +27,6 @@ import (
 func main() {
 	// Create YarnClient
 	yarnClient, _ := yarnclient.CreateYarnClient()
-	yarnClient.Initialize()
 
 	host := "0.0.0.0"
 	port := int32(8041)

--- a/pkg/yarn/client/examples/rm-update-node-resource/main.go
+++ b/pkg/yarn/client/examples/rm-update-node-resource/main.go
@@ -28,7 +28,7 @@ import (
 
 func main() {
 	// Create YarnConfiguration
-	conf, _ := yarnconf.NewYarnConfiguration(os.Getenv("HADOOP_CONF_DIR"))
+	conf, _ := yarnconf.NewYarnConfiguration(os.Getenv("HADOOP_CONF_DIR"), "")
 
 	// Create YarnAdminClient
 	yarnAdminClient, _ := yarnclient.CreateYarnAdminClient(conf, nil)

--- a/pkg/yarn/config/configuration.go
+++ b/pkg/yarn/config/configuration.go
@@ -96,10 +96,10 @@ func (conf *configuration) SetInt(key string, value int) error {
 }
 
 func NewConfiguration(hadoopConfDir string) (Configuration, error) {
-	return NewConfigurationResources(hadoopConfDir, []Resource{})
+	return NewConfigurationResources(hadoopConfDir, []Resource{}, "")
 }
 
-func NewConfigurationResources(hadoopConfDir string, resources []Resource) (Configuration, error) {
+func NewConfigurationResources(hadoopConfDir string, resources []Resource, prefix string) (Configuration, error) {
 	// Add $HADOOP_CONF_DIR/core-default.xml & $HADOOP_CONF_DIR/core-site.xml
 	resourcesWithDefault := []Resource{CORE_DEFAULT, CORE_SITE}
 	resourcesWithDefault = append(resourcesWithDefault, resources...)
@@ -107,7 +107,7 @@ func NewConfigurationResources(hadoopConfDir string, resources []Resource) (Conf
 	c := configuration{Properties: make(map[string]string)}
 
 	for _, resource := range resourcesWithDefault {
-		conf, err := os.Open(hadoopConfDir + string(os.PathSeparator) + resource.Name)
+		conf, err := os.Open(hadoopConfDir + string(os.PathSeparator) + prefix + resource.Name)
 		if err != nil {
 			if !resource.Required {
 				continue

--- a/pkg/yarn/config/yarn_configuration.go
+++ b/pkg/yarn/config/yarn_configuration.go
@@ -67,33 +67,33 @@ type YarnConfiguration interface {
 	SetInt(key string, value int) error
 }
 
-func (yarn_conf *yarn_configuration) Get(key string, defaultValue string) (string, error) {
-	return yarn_conf.conf.Get(key, defaultValue)
+func (yarnConf *yarn_configuration) Get(key string, defaultValue string) (string, error) {
+	return yarnConf.conf.Get(key, defaultValue)
 }
 
-func (yarn_conf *yarn_configuration) GetInt(key string, defaultValue int) (int, error) {
-	return yarn_conf.conf.GetInt(key, defaultValue)
+func (yarnConf *yarn_configuration) GetInt(key string, defaultValue int) (int, error) {
+	return yarnConf.conf.GetInt(key, defaultValue)
 }
 
-func (yarn_conf *yarn_configuration) GetRMAddress() (string, error) {
-	return yarn_conf.conf.Get(RM_ADDRESS, DEFAULT_RM_ADDRESS)
+func (yarnConf *yarn_configuration) GetRMAddress() (string, error) {
+	return yarnConf.conf.Get(RM_ADDRESS, DEFAULT_RM_ADDRESS)
 }
 
-func (yarn_conf *yarn_configuration) GetRMSchedulerAddress() (string, error) {
-	return yarn_conf.conf.Get(RM_SCHEDULER_ADDRESS, DEFAULT_RM_SCHEDULER_ADDRESS)
+func (yarnConf *yarn_configuration) GetRMSchedulerAddress() (string, error) {
+	return yarnConf.conf.Get(RM_SCHEDULER_ADDRESS, DEFAULT_RM_SCHEDULER_ADDRESS)
 }
 
-func (yarn_conf *yarn_configuration) GetRMAdminAddress() (string, error) {
-	return yarn_conf.conf.Get(RM_ADMIN_ADDRESS, DEFAULT_RM_ADMIN_ADDRESS)
+func (yarnConf *yarn_configuration) GetRMAdminAddress() (string, error) {
+	return yarnConf.conf.Get(RM_ADMIN_ADDRESS, DEFAULT_RM_ADMIN_ADDRESS)
 }
 
-func (yarn_conf *yarn_configuration) GetRMEnabledHA() (bool, error) {
-	return yarn_conf.conf.GetBool(RM_HA_ENABLED, DEFAULT_RM_HA_ENABLED)
+func (yarnConf *yarn_configuration) GetRMEnabledHA() (bool, error) {
+	return yarnConf.conf.GetBool(RM_HA_ENABLED, DEFAULT_RM_HA_ENABLED)
 }
 
-func (yarn_conf *yarn_configuration) GetRMs() ([]string, error) {
+func (yarnConf *yarn_configuration) GetRMs() ([]string, error) {
 	rmIDs := make([]string, 0)
-	allRMs, err := yarn_conf.conf.Get(RM_HA_RM_IDS, "")
+	allRMs, err := yarnConf.conf.Get(RM_HA_RM_IDS, "")
 	if err != nil {
 		return rmIDs, nil
 	}
@@ -101,35 +101,43 @@ func (yarn_conf *yarn_configuration) GetRMs() ([]string, error) {
 	return rmIDs, nil
 }
 
-func (yarn_conf *yarn_configuration) GetRMAdminAddressByID(rmID string) (string, error) {
+func (yarnConf *yarn_configuration) GetRMAdminAddressByID(rmID string) (string, error) {
 	// yarn.resourcemanager.admin.address.rm1
 	rmAddrKey := fmt.Sprintf("%v.%v", RM_ADMIN_ADDRESS, rmID)
-	return yarn_conf.conf.Get(rmAddrKey, DEFAULT_RM_ADMIN_ADDRESS)
+	return yarnConf.conf.Get(rmAddrKey, DEFAULT_RM_ADMIN_ADDRESS)
 }
 
-func (yarn_conf *yarn_configuration) GetRMAddressByID(rmID string) (string, error) {
+func (yarnConf *yarn_configuration) GetRMAddressByID(rmID string) (string, error) {
 	// yarn.resourcemanager.address.rm1
 	rmAddrKey := fmt.Sprintf("%v.%v", RM_ADDRESS, rmID)
-	return yarn_conf.conf.Get(rmAddrKey, DEFAULT_RM_ADDRESS)
+	return yarnConf.conf.Get(rmAddrKey, DEFAULT_RM_ADDRESS)
 }
 
-func (yarn_conf *yarn_configuration) Set(key string, value string) error {
-	return yarn_conf.conf.Set(key, value)
+func (yarnConf *yarn_configuration) Set(key string, value string) error {
+	return yarnConf.conf.Set(key, value)
 }
 
-func (yarn_conf *yarn_configuration) SetInt(key string, value int) error {
-	return yarn_conf.conf.SetInt(key, value)
+func (yarnConf *yarn_configuration) SetInt(key string, value int) error {
+	return yarnConf.conf.SetInt(key, value)
 }
 
-func (yarn_conf *yarn_configuration) SetRMAddress(address string) error {
-	return yarn_conf.conf.Set(RM_ADDRESS, address)
+func (yarnConf *yarn_configuration) SetRMAddress(address string) error {
+	return yarnConf.conf.Set(RM_ADDRESS, address)
 }
 
-func (yarn_conf *yarn_configuration) SetRMSchedulerAddress(address string) error {
-	return yarn_conf.conf.Set(RM_SCHEDULER_ADDRESS, address)
+func (yarnConf *yarn_configuration) SetRMSchedulerAddress(address string) error {
+	return yarnConf.conf.Set(RM_SCHEDULER_ADDRESS, address)
 }
 
-func NewYarnConfiguration(hadooConfDir string) (YarnConfiguration, error) {
-	c, err := NewConfigurationResources(hadooConfDir, []Resource{YARN_DEFAULT, YARN_SITE})
+func NewYarnConfiguration(hadooConfDir string, clusterID string) (YarnConfiguration, error) {
+	// for yarn-site.xml with cluster id, read from clusterid.yarn-site.xml
+	c, err := NewConfigurationResources(hadooConfDir, []Resource{YARN_DEFAULT, YARN_SITE}, configPrefix(clusterID))
 	return &yarn_configuration{conf: c}, err
+}
+
+func configPrefix(clusterID string) string {
+	if clusterID != "" {
+		return clusterID + "."
+	}
+	return ""
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
nm pods in k8s may belongs to multiple yarn clusters.
yarn operator supports sync batch resource to different yarn rm.

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it
1. Add cluster id to annotation of nm pod:
kubectl annotate pod $yarn-nm-pod yarn.hadoop.apache.org/cluster-id: test-cluster-id
```yaml
  annotations:
    yarn.hadoop.apache.org/cluster-id: test-cluster-id
```

2. create ConfigMap with yarn config by cluster, the prefix of config key `test-cluster-id` must be equal to the nm pod annotation.
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: yarn-config
  namespace: koordinator-system
data:
  yarn-site.xml: |
    <configuration>
        ......
    </configuration>
  # format: ${cluster-id}.yarn-site.xml
  test-cluster-id.yarn-site.xml: |
    <configuration>
        ......
    </configuration>
```
4. should restart yarn-operator if new yarn config added

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
