### PR TITLE
koord-yarn-operator: add cache filter in Manager to reduce memory occupied by the koord-yarn-operator.

### DIFF
--- a/cmd/yarn-operator/main.go
+++ b/cmd/yarn-operator/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"math/rand"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"time"
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When we used yarn-operator internally for yarn mixing, we found that the yarn-operator component took up a lot of memory. Through pprof inspection, we found that `ListAndWatch` took up a lot of memory. Finally, we found that the reason was the `field index`. Therefore, we modified the default Cache so that the `field index` only focuses on the NMpod of interest.
![image](https://github.com/user-attachments/assets/f4e1cf04-0169-4f50-af68-5f4932890159)

before:
![image](https://github.com/user-attachments/assets/7199e187-2426-4012-8bdd-9fb78e50dca7)

after:
![image](https://github.com/user-attachments/assets/5beea78d-c669-4704-add3-059bf576bf57)


### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `make test`
