### PR TITLE
fix: fix yarn-copilot pprof

### DIFF
--- a/cmd/yarn-operator/main.go
+++ b/cmd/yarn-operator/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"math/rand"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"time"
 


### PR DESCRIPTION
according to https://pkg.go.dev/net/http/pprof,
"net/http/pprof" should be imported

### Ⅰ. Describe what this PR does
according to https://pkg.go.dev/net/http/pprof, 
"net/http/pprof" should be imported

> To use pprof, link this package into your program:
```
import _ "net/http/pprof"
```

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
