### PR TITLE
feat: yarn client support kerberos auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,8 @@ require (
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/golang/mock v1.6.0
+	github.com/jcmturner/gofork v1.7.6
+	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/opencontainers/runc v1.1.6
 	github.com/stretchr/testify v1.8.2
 )
@@ -118,8 +120,12 @@ require (
 	github.com/google/cadvisor v0.44.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 // indirect
+	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hodgesds/perf-utils v0.5.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
+	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
+	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -471,6 +471,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
@@ -505,6 +507,9 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
+github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -532,6 +537,18 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ionos-cloud/sdk-go/v6 v6.1.3 h1:vb6yqdpiqaytvreM0bsn2pXw+1YDvEk2RKSmBAQvgDQ=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
+github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
+github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
+github.com/jcmturner/dnsutils/v2 v2.0.0 h1:lltnkeZGL0wILNvrNiVCR6Ro5PGU/SeBvVO/8c/iPbo=
+github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=
+github.com/jcmturner/gofork v1.7.6 h1:QH0l3hzAU1tfT3rZCnW5zXl+orbkNMMRGJfdJjHVETg=
+github.com/jcmturner/gofork v1.7.6/go.mod h1:1622LH6i/EZqLloHfE7IeZ0uEJwMSUyQ/nDd82IeqRo=
+github.com/jcmturner/goidentity/v6 v6.0.1 h1:VKnZd2oEIMorCTsFBnJWbExfNN7yZr3EhJAxwOkZg6o=
+github.com/jcmturner/goidentity/v6 v6.0.1/go.mod h1:X1YW3bgtvwAXju7V3LCIMpY0Gbxyjn/mY9zx4tFonSg=
+github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh687T8=
+github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
+github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
+github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -852,6 +869,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/pkg/yarn/apis/auth/auth.go
+++ b/pkg/yarn/apis/auth/auth.go
@@ -50,6 +50,22 @@ const (
 	AUTH_PLAIN    AuthMethod = 0x53
 )
 
+func ConvertAuthProtoToAuthMethod(authProto *hadoop_common.RpcSaslProto_SaslAuth) AuthMethod {
+	method := authProto.GetMethod()
+	mechanism := authProto.GetMechanism()
+
+	switch {
+	case method == "TOKEN" && mechanism == "DIGEST-MD5":
+		return AUTH_TOKEN
+	case method == "KERBEROS" && mechanism == "GSSAPI":
+		return AUTH_KERBEROS
+	case method == "PLAIN":
+		return AUTH_PLAIN
+	}
+
+	return AUTH_SIMPLE
+}
+
 func (authmethod AuthMethod) String() string {
 	switch {
 	case authmethod == AUTH_SIMPLE:

--- a/pkg/yarn/apis/auth/auth.go
+++ b/pkg/yarn/apis/auth/auth.go
@@ -67,14 +67,14 @@ func ConvertAuthProtoToAuthMethod(authProto *hadoop_common.RpcSaslProto_SaslAuth
 }
 
 func (authmethod AuthMethod) String() string {
-	switch {
-	case authmethod == AUTH_SIMPLE:
+	switch authmethod {
+	case AUTH_SIMPLE:
 		return "SIMPLE"
-	case authmethod == AUTH_KERBEROS:
+	case AUTH_KERBEROS:
 		return "GSSAPI"
-	case authmethod == AUTH_TOKEN:
+	case AUTH_TOKEN:
 		return "DIGEST-MD5"
-	case authmethod == AUTH_PLAIN:
+	case AUTH_PLAIN:
 		return "PLAIN"
 	}
 	return "ERROR-UNKNOWN"
@@ -88,10 +88,10 @@ const (
 )
 
 func (authprotocol AuthProtocol) String() string {
-	switch {
-	case authprotocol == AUTH_PROTOCOL_NONE:
+	switch authprotocol {
+	case AUTH_PROTOCOL_NONE:
 		return "NONE"
-	case authprotocol == AUTH_PROTOCOL_SASL:
+	case AUTH_PROTOCOL_SASL:
 		return "SASL"
 	}
 	return "ERROR-UNKNOWN"

--- a/pkg/yarn/apis/service/ha_service.go
+++ b/pkg/yarn/apis/service/ha_service.go
@@ -25,7 +25,9 @@ import (
 
 	gohadoop "github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/auth"
 	"github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/proto/hadoopcommon"
+	"github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/security"
 	hadoop_ipc_client "github.com/koordinator-sh/yarn-copilot/pkg/yarn/client/ipc"
+	yarn_conf "github.com/koordinator-sh/yarn-copilot/pkg/yarn/config"
 )
 
 // Reference proto, json, and math imports to suppress error if they are not otherwise used.
@@ -47,9 +49,13 @@ func (c *HAServiceProtocolServiceClient) GetServiceStatus(in *hadoopcommon.GetSe
 	return c.Call(gohadoop.GetCalleeRPCRequestHeaderProto(&HA_SERVICE_PROTOCOL), in, out)
 }
 
-func DialHAServiceProtocolService(serverAddress string) (HAServiceProtocolService, error) {
+func DialHAServiceProtocolService(serverAddress string, conf yarn_conf.YarnConfiguration) (HAServiceProtocolService, error) {
 	clientId, _ := uuid.NewV4()
-	ugi, _ := gohadoop.CreateSimpleUGIProto()
-	c := &hadoop_ipc_client.Client{ClientId: clientId, Ugi: ugi, ServerAddress: serverAddress}
+	ugi, _ := security.CreateUserGroupInformation(conf)
+	c := &hadoop_ipc_client.Client{
+		ClientId:      clientId,
+		UGI:           ugi,
+		ServerAddress: serverAddress,
+	}
 	return &HAServiceProtocolServiceClient{c}, nil
 }

--- a/pkg/yarn/apis/service/resourcemanager_administration_service.go
+++ b/pkg/yarn/apis/service/resourcemanager_administration_service.go
@@ -25,6 +25,7 @@ import (
 
 	gohadoop "github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/auth"
 	yarnserver "github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/proto/hadoopyarn/server"
+	"github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/security"
 	hadoop_ipc_client "github.com/koordinator-sh/yarn-copilot/pkg/yarn/client/ipc"
 	yarn_conf "github.com/koordinator-sh/yarn-copilot/pkg/yarn/config"
 )
@@ -56,7 +57,7 @@ func DialResourceManagerAdministrationProtocolService(conf yarn_conf.YarnConfigu
 	if err != nil {
 		return nil, err
 	}
-	ugi, err := gohadoop.CreateSimpleUGIProto()
+	ugi, err := security.CreateUserGroupInformation(conf)
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +69,16 @@ func DialResourceManagerAdministrationProtocolService(conf yarn_conf.YarnConfigu
 		return nil, err
 	}
 
-	c := &hadoop_ipc_client.Client{ClientId: clientId, Ugi: ugi, ServerAddress: serverAddress}
+	var tcpNoDelay bool
+	if tcpNoDelay, err = conf.GetIPCClientTcpNoDelay(); err != nil {
+		return nil, err
+	}
+
+	c := &hadoop_ipc_client.Client{
+		ClientId:      clientId,
+		UGI:           ugi,
+		ServerAddress: serverAddress,
+		TCPNoDelay:    tcpNoDelay,
+	}
 	return &ResourceManagerAdministrationProtocolServiceClient{c}, nil
 }

--- a/pkg/yarn/client/examples/ha-get-service-status/main.go
+++ b/pkg/yarn/client/examples/ha-get-service-status/main.go
@@ -44,7 +44,7 @@ func main() {
 		}
 
 		// Create YarnAdminClient
-		yarnHAClient, _ := yarnclient.CreateYarnHAClient(rmAddr)
+		yarnHAClient, _ := yarnclient.CreateYarnHAClient(rmAddr, conf)
 
 		request := &hadoopcommon.GetServiceStatusRequestProto{}
 		response, err := yarnHAClient.GetServiceStatus(request)

--- a/pkg/yarn/client/examples/rm-get-cluster-nodes-with-ha/main.go
+++ b/pkg/yarn/client/examples/rm-get-cluster-nodes-with-ha/main.go
@@ -33,8 +33,16 @@ func main() {
 	response, err := yarnClient.GetClusterNodes(request)
 
 	if err != nil {
-		log.Fatal("GetClusterNode ", err)
+		log.Fatalf("failed: GetClusterNode %v", err)
 	}
 
-	log.Printf("GetClusterNode response %v", response)
+	log.Printf("success: GetClusterNode response %+v", response)
+
+	for _, nodereport := range response.NodeReports {
+		log.Printf("node %+v\n", nodereport)
+		log.Printf("used %s\n", *nodereport.HttpAddress)
+		log.Printf("used virtual cpu %d\n", *nodereport.Used.VirtualCores)
+		log.Printf("used memory %d\n", *nodereport.Used.Memory)
+		log.Printf("used resource map %+v\n", nodereport.Used.ResourceValueMap)
+	}
 }

--- a/pkg/yarn/client/ha_service_client.go
+++ b/pkg/yarn/client/ha_service_client.go
@@ -19,14 +19,15 @@ package client
 import (
 	"github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/proto/hadoopcommon"
 	yarnservice "github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/service"
+	yarn_conf "github.com/koordinator-sh/yarn-copilot/pkg/yarn/config"
 )
 
 type YarnHAClient struct {
 	client yarnservice.HAServiceProtocolService
 }
 
-func CreateYarnHAClient(rmAddress string) (*YarnHAClient, error) {
-	c, err := yarnservice.DialHAServiceProtocolService(rmAddress)
+func CreateYarnHAClient(rmAddress string, conf yarn_conf.YarnConfiguration) (*YarnHAClient, error) {
+	c, err := yarnservice.DialHAServiceProtocolService(rmAddress, conf)
 	return &YarnHAClient{client: c}, err
 }
 

--- a/pkg/yarn/client/ipc/client.go
+++ b/pkg/yarn/client/ipc/client.go
@@ -24,7 +24,10 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	gouuid "github.com/nu7hatch/gouuid"
@@ -42,11 +45,20 @@ const (
 	rwDefaultTimeout   = 5 * time.Second
 )
 
+var (
+	saslNegotiateState   = hadoop_common.RpcSaslProto_NEGOTIATE
+	saslNegotiateMessage = hadoop_common.RpcSaslProto{
+		State: &saslNegotiateState,
+	}
+)
+
 type Client struct {
 	ClientId      *gouuid.UUID
-	Ugi           *hadoop_common.UserInformationProto
+	UGI           *security.UserGroupInformation
 	ServerAddress string
+
 	TCPNoDelay    bool
+	TCPLowLatency bool
 }
 
 type connection struct {
@@ -54,7 +66,6 @@ type connection struct {
 }
 
 type connection_id struct {
-	user     string
 	protocol string
 	address  string
 	ClientId gouuid.UUID
@@ -81,12 +92,16 @@ var (
 	SASL_RPC_DUMMY_CLIENT_ID     []byte = make([]byte, 0)
 	SASL_RPC_CALL_ID             int32  = -33
 	SASL_RPC_INVALID_RETRY_COUNT int32  = -1
+
+	AUTHORIZATION_FAILED_CALL_ID int32 = -1
+	INVALID_CALL_ID              int32 = -2
+	CONNECTION_CONTEXT_CALL_ID   int32 = -3
+	PING_CALL_ID                 int32 = -4
 )
 
 func (c *Client) Call(rpc *hadoop_common.RequestHeaderProto, rpcRequest proto.Message, rpcResponse proto.Message) error {
 	// Create connection_id
 	connectionId := connection_id{
-		user:     *c.Ugi.RealUser,
 		protocol: *rpc.DeclaringClassProtocolName,
 		address:  c.ServerAddress,
 		ClientId: *c.ClientId,
@@ -103,23 +118,20 @@ func (c *Client) Call(rpc *hadoop_common.RequestHeaderProto, rpcRequest proto.Me
 	rpcCall := call{callId: 0, procedure: rpc, request: rpcRequest, response: rpcResponse}
 	err = sendRequest(c, conn, &rpcCall)
 	if err != nil {
-		klog.Warningf("sendRequest", err)
+		klog.Errorf("sendRequest error: %v", err)
 		return err
 	}
 
 	// Read & return response
 	err = c.readResponse(conn, &rpcCall)
 
-	// TODO keep connection alive for reuse
-	conn.con.Close()
-
 	return err
 }
 
-//var connectionPool = struct {
-//	sync.RWMutex
-//	connections map[connection_id]*connection
-//}{connections: make(map[connection_id]*connection)}
+var connectionPool = struct {
+	sync.RWMutex
+	connections map[connection_id]*connection
+}{connections: make(map[connection_id]*connection)}
 
 func findUsableTokenForService(service string) (*hadoop_common.TokenProto, bool) {
 	userTokens := security.GetCurrentUser().GetUserTokens()
@@ -138,56 +150,69 @@ func findUsableTokenForService(service string) (*hadoop_common.TokenProto, bool)
 	return nil, false
 }
 
-func getConnection(c *Client, connectionId *connection_id) (*connection, error) {
-	// Try to re-use an existing connection
-	//connectionPool.RLock()
-	//con := connectionPool.connections[*connectionId]
-	//connectionPool.RUnlock()
+func getAuthProtocol(c *Client) yarnauth.AuthProtocol {
+	authProtocol := yarnauth.AUTH_PROTOCOL_NONE
 
-	// If necessary, create a new connection and save it in the connection-pool
-	//var err error
-	//if con == nil {
-	con, err := setupConnection(c)
-	if err != nil {
-		klog.Warningf("Couldn't setup connection: %v", err)
-		return nil, err
-	}
-
-	//connectionPool.Lock()
-	//connectionPool.connections[*connectionId] = con
-	//connectionPool.Unlock()
-
-	var authProtocol yarnauth.AuthProtocol = yarnauth.AUTH_PROTOCOL_NONE
-
+	// TODO: check if we have a token for the service
 	if _, found := findUsableTokenForService(c.ServerAddress); found {
 		klog.V(4).Infof("found token for service: %s", c.ServerAddress)
 		authProtocol = yarnauth.AUTH_PROTOCOL_SASL
 	}
 
-	err = writeConnectionHeader(con, authProtocol)
+	if c.UGI.IsSecurityEnabled() {
+		authProtocol = yarnauth.AUTH_PROTOCOL_SASL
+	}
+
+	return authProtocol
+}
+
+func getConnection(c *Client, connectionId *connection_id) (conn *connection, err error) {
+	// Try to re-use an existing connection
+	connectionPool.RLock()
+	conn = connectionPool.connections[*connectionId]
+	connectionPool.RUnlock()
+
+	if conn != nil {
+		return conn, nil
+	}
+
+	// If necessary, create a new connection and save it in the connection-pool
+	conn, err = setupConnection(c)
 	if err != nil {
+		klog.Errorf("couldn't setup connection: %v", err)
 		return nil, err
 	}
 
-	if authProtocol == yarnauth.AUTH_PROTOCOL_SASL {
-		klog.V(4).Infof("attempting SASL negotiation.")
+	connectionPool.Lock()
+	connectionPool.connections[*connectionId] = conn
+	connectionPool.Unlock()
 
-		if err = negotiateSimpleTokenAuth(c, con); err != nil {
-			klog.Warningf("failed to complete SASL negotiation!")
+	authProtocol := getAuthProtocol(c)
+	err = writeConnectionHeader(conn, authProtocol)
+	if err != nil {
+		return nil, err
+	}
+	var authMethod yarnauth.AuthMethod
+	if authProtocol == yarnauth.AUTH_PROTOCOL_SASL {
+		authMethod, err = setupSaslConnection(c, conn)
+		if err != nil {
+			klog.Errorf("couldn't setup sasl connection: %v", err)
 			return nil, err
 		}
-
-	} else {
-		klog.V(5).Infof("no usable tokens. proceeding without auth.")
+		klog.V(5).Infof("proceeding with sasl. auth method: %v", authMethod)
 	}
 
-	err = writeConnectionContext(c, con, connectionId, authProtocol)
+	err = writeConnectionContext(c, conn, connectionId, authMethod)
 	if err != nil {
 		return nil, err
 	}
-	//}
 
-	return con, nil
+	return conn, nil
+}
+
+func setupSaslConnection(c *Client, con *connection) (yarnauth.AuthMethod, error) {
+	authMethod, err := saslConnect(c, con)
+	return *authMethod, err
 }
 
 func setupConnection(c *Client) (*connection, error) {
@@ -196,9 +221,14 @@ func setupConnection(c *Client) (*connection, error) {
 	if err != nil {
 		klog.V(4).Infof("error: %v", err)
 		return nil, err
-	} else {
-		klog.V(5).Infof("setup connection success %v", c)
 	}
+
+	// close the connection if we fail to setup the connection
+	defer func() {
+		if err != nil {
+			conn.Close()
+		}
+	}()
 
 	tcpConn, ok := conn.(*net.TCPConn)
 	if !ok {
@@ -213,7 +243,114 @@ func setupConnection(c *Client) (*connection, error) {
 		return nil, err
 	}
 
+	err = tcpConn.SetKeepAlive(true)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.TCPLowLatency {
+		var fd *os.File
+		if fd, err = tcpConn.File(); err != nil {
+			return nil, err
+		}
+		defer fd.Close()
+
+		/*
+			This allows intermediate switches to shape IPC traffic
+			differently from Shuffle/HDFS DataStreamer traffic.
+			IPTOS_RELIABILITY (0x04) | IPTOS_LOWDELAY (0x10)
+			Prefer to optimize connect() speed & response latency over net
+			throughput.
+		*/
+		sockFd := int(fd.Fd())
+		if err = syscall.SetsockoptInt(sockFd, syscall.IPPROTO_IP, syscall.IP_TOS, 0x14); err != nil {
+			return nil, err
+		}
+		// TODO socket.setPerformancePreferences(1, 2, 0)
+	}
+
 	return &connection{tcpConn}, nil
+}
+
+func saslConnect(client *Client, con *connection) (*yarnauth.AuthMethod, error) {
+	authMethod := yarnauth.AUTH_SIMPLE
+
+	// send a SASL negotiation request
+	if err := sendSaslMessage(con, &saslNegotiateMessage); err != nil {
+		klog.Warningf("failed to send SASL NEGOTIATE message!")
+		return nil, err
+	}
+
+	var saslClient SASLClient
+	done := false
+	for !done {
+		saslResponseMessage, err := receiveSaslMessage(con)
+		if err != nil {
+			klog.Error("failed to receive SASL NEGOTIATE response!")
+			return nil, err
+		}
+
+		challengeToken := saslResponseMessage.GetToken()
+		var rpcResponse *hadoop_common.RpcSaslProto
+
+		switch saslResponseMessage.GetState() {
+		case hadoop_common.RpcSaslProto_NEGOTIATE:
+			auth, client, err := selectSaslClient(client, saslResponseMessage.GetAuths())
+			if err != nil {
+				klog.Error("failed to select SASL client!")
+				return nil, err
+			}
+			saslClient = client
+			authMethod = yarnauth.ConvertAuthProtoToAuthMethod(auth)
+
+			var responseToken []byte
+			if authMethod == yarnauth.AUTH_SIMPLE {
+				done = true
+			} else {
+				if auth.GetChallenge() != nil {
+					challengeToken = auth.GetChallenge()
+					// TODO clean auth challenge
+				} else {
+					// TODO check saslClient.hasInitialResponse
+					challengeToken = []byte{}
+				}
+				responseToken, err = saslClient.EvaluateChallenge(challengeToken)
+				if err != nil {
+					klog.Error("failed to evaluate challenge!")
+					return nil, err
+				}
+			}
+			rpcResponse = createSaslReply(hadoop_common.RpcSaslProto_INITIATE, responseToken)
+			rpcResponse.Auths = append(rpcResponse.Auths, auth)
+		case hadoop_common.RpcSaslProto_CHALLENGE:
+			if saslClient == nil {
+				return nil, errors.New("sasl client is nil")
+			}
+			responseToken, err := saslClient.EvaluateChallenge(challengeToken)
+			if err != nil {
+				klog.Error("failed to evaluate challenge!")
+				return nil, err
+			}
+			rpcResponse = createSaslReply(hadoop_common.RpcSaslProto_RESPONSE, responseToken)
+		case hadoop_common.RpcSaslProto_SUCCESS:
+			if saslClient == nil {
+				authMethod = yarnauth.AUTH_SIMPLE
+			} else {
+				// ignore error
+				saslClient.EvaluateChallenge(challengeToken)
+			}
+			done = true
+		}
+
+		if rpcResponse != nil {
+			if err = sendSaslMessage(con, rpcResponse); err != nil {
+				klog.Error("failed to send SASL message!")
+				return nil, err
+			}
+		}
+	}
+
+	return &authMethod, nil
 }
 
 func writeConnectionHeader(conn *connection, authProtocol yarnauth.AuthProtocol) error {
@@ -253,23 +390,45 @@ func writeConnectionHeader(conn *connection, authProtocol yarnauth.AuthProtocol)
 	return nil
 }
 
-func writeConnectionContext(c *Client, conn *connection, connectionId *connection_id, authProtocol yarnauth.AuthProtocol) error {
+func writeConnectionContext(c *Client, conn *connection, connectionId *connection_id, authMethod yarnauth.AuthMethod) error {
 	if err := conn.con.SetDeadline(time.Now().Add(rwDefaultTimeout)); err != nil {
 		return err
 	}
-	// Create hadoop_common.IpcConnectionContextProto
-	ugi, _ := yarnauth.CreateSimpleUGIProto()
-	ipcCtxProto := hadoop_common.IpcConnectionContextProto{UserInfo: ugi, Protocol: &connectionId.protocol}
+	// TODO fix me
+	// ugiProto := &hadoop_common.UserInformationProto{}
+	// if c.UGI != nil {
+	// 	if authMethod == yarnauth.AUTH_KERBEROS {
+	// 		// Real user was established as part of the connection.
+	// 		// Send effective user only.
+	// 		effectiveUser := c.UGI.GetEffectiveUser()
+	// 		ugiProto.EffectiveUser = &effectiveUser
+	// 	} else if authMethod == yarnauth.AUTH_TOKEN {
+	// 		// With token, the connection itself establishes
+	// 		// both real and effective user. Hence send none in header
+	// 	} else { // Simple authentication
+	// 		// No user info is established as part of the connection.
+	// 		// Send both effective user and real user
+	// 		effectiveUser := c.UGI.GetEffectiveUser()
+	// 		ugiProto.EffectiveUser = &effectiveUser
+	// 		if realUser := c.UGI.GetRealUser(); realUser != "" {
+	// 			ugiProto.RealUser = &realUser
+	// 		}
+	// 	}
+	// }
+	ugiProto, _ := yarnauth.CreateSimpleUGIProto()
+	ipcCtxProto := hadoop_common.IpcConnectionContextProto{Protocol: &connectionId.protocol}
+	ipcCtxProto.UserInfo = ugiProto
 
 	// Create RpcRequestHeaderProto
-	var callId int32 = -3
 	var clientId [16]byte = [16]byte(*c.ClientId)
 
-	/*if (authProtocol == yarnauth.AUTH_PROTOCOL_SASL) {
-	  callId = SASL_RPC_CALL_ID
-	}*/
-
-	rpcReqHeaderProto := hadoop_common.RpcRequestHeaderProto{RpcKind: &yarnauth.RPC_PROTOCOL_BUFFFER, RpcOp: &yarnauth.RPC_FINAL_PACKET, CallId: &callId, ClientId: clientId[0:16], RetryCount: &yarnauth.RPC_DEFAULT_RETRY_COUNT}
+	rpcReqHeaderProto := hadoop_common.RpcRequestHeaderProto{
+		RpcKind:    &yarnauth.RPC_PROTOCOL_BUFFFER,
+		RpcOp:      &yarnauth.RPC_FINAL_PACKET,
+		CallId:     &CONNECTION_CONTEXT_CALL_ID,
+		ClientId:   clientId[0:16],
+		RetryCount: &yarnauth.RPC_DEFAULT_RETRY_COUNT,
+	}
 
 	rpcReqHeaderProtoBytes, err := proto.Marshal(&rpcReqHeaderProto)
 	if err != nil {
@@ -327,7 +486,13 @@ func sendRequest(c *Client, conn *connection, rpcCall *call) error {
 
 	// 0. RpcRequestHeaderProto
 	var clientId [16]byte = [16]byte(*c.ClientId)
-	rpcReqHeaderProto := hadoop_common.RpcRequestHeaderProto{RpcKind: &yarnauth.RPC_PROTOCOL_BUFFFER, RpcOp: &yarnauth.RPC_FINAL_PACKET, CallId: &rpcCall.callId, ClientId: clientId[0:16], RetryCount: &rpcCall.retryCount}
+	rpcReqHeaderProto := hadoop_common.RpcRequestHeaderProto{
+		RpcKind:    &yarnauth.RPC_PROTOCOL_BUFFFER,
+		RpcOp:      &yarnauth.RPC_FINAL_PACKET,
+		CallId:     &rpcCall.callId,
+		ClientId:   clientId[0:16],
+		RetryCount: &rpcCall.retryCount,
+	}
 	rpcReqHeaderProtoBytes, err := proto.Marshal(&rpcReqHeaderProto)
 	if err != nil {
 		klog.Warningf("proto.Marshal(&rpcReqHeaderProto) %v", err)
@@ -375,7 +540,7 @@ func sendRequest(c *Client, conn *connection, rpcCall *call) error {
 		return err
 	}
 
-	klog.V(5).Infof("Succesfully sent request of length: ", totalLength)
+	klog.V(5).Infof("Succesfully sent request of length: %v", totalLength)
 
 	return nil
 }
@@ -438,7 +603,7 @@ func (c *Client) readResponse(conn *connection, rpcCall *call) error {
 
 	err = c.checkRpcHeader(&rpcResponseHeaderProto)
 	if err != nil {
-		klog.Warningf("c.checkRpcHeader failed %v", err)
+		klog.Warningf("c.checkRpcHeader failed %v, rpc header %+v", err, &rpcResponseHeaderProto)
 		return err
 	}
 
@@ -447,7 +612,11 @@ func (c *Client) readResponse(conn *connection, rpcCall *call) error {
 		_, err = readDelimited(responseBytes[off:], rpcCall.response)
 	} else {
 		klog.V(4).Infof("RPC failed with status: %v", rpcResponseHeaderProto.Status.String())
-		errorDetails := [4]string{rpcResponseHeaderProto.Status.String(), "ServerDidNotSetExceptionClassName", "ServerDidNotSetErrorMsg", "ServerDidNotSetErrorDetail"}
+		errorDetails := [4]string{
+			rpcResponseHeaderProto.Status.String(),
+			"ServerDidNotSetExceptionClassName",
+			"ServerDidNotSetErrorMsg",
+			"ServerDidNotSetErrorDetail"}
 		if rpcResponseHeaderProto.ExceptionClassName != nil {
 			errorDetails[0] = *rpcResponseHeaderProto.ExceptionClassName
 		}
@@ -484,18 +653,20 @@ func (c *Client) checkRpcHeader(rpcResponseHeaderProto *hadoop_common.RpcRespons
 	if rpcResponseHeaderProto.ClientId != nil {
 		if !bytes.Equal(callClientId[0:16], headerClientId[0:16]) {
 			klog.Warningf("Incorrect clientId: %v", headerClientId)
-			return errors.New("Incorrect clientId")
+			return errors.New("incorrect clientId")
 		}
 	}
 	return nil
 }
 
-func sendSaslMessage(c *Client, conn *connection, message *hadoop_common.RpcSaslProto) error {
-	saslRpcHeaderProto := hadoop_common.RpcRequestHeaderProto{RpcKind: &yarnauth.RPC_PROTOCOL_BUFFFER,
+func sendSaslMessage(conn *connection, message *hadoop_common.RpcSaslProto) error {
+	saslRpcHeaderProto := hadoop_common.RpcRequestHeaderProto{
+		RpcKind:    &yarnauth.RPC_PROTOCOL_BUFFFER,
 		RpcOp:      &yarnauth.RPC_FINAL_PACKET,
 		CallId:     &SASL_RPC_CALL_ID,
 		ClientId:   SASL_RPC_DUMMY_CLIENT_ID,
-		RetryCount: &SASL_RPC_INVALID_RETRY_COUNT}
+		RetryCount: &SASL_RPC_INVALID_RETRY_COUNT,
+	}
 
 	saslRpcHeaderProtoBytes, err := proto.Marshal(&saslRpcHeaderProto)
 
@@ -537,7 +708,7 @@ func sendSaslMessage(c *Client, conn *connection, message *hadoop_common.RpcSasl
 	return nil
 }
 
-func receiveSaslMessage(c *Client, conn *connection) (*hadoop_common.RpcSaslProto, error) {
+func receiveSaslMessage(conn *connection) (*hadoop_common.RpcSaslProto, error) {
 	// Read first 4 bytes to get total-length
 	var totalLength int32 = -1
 	var totalLengthBytes [4]byte
@@ -608,87 +779,71 @@ func checkSaslRpcHeader(rpcResponseHeaderProto *hadoop_common.RpcResponseHeaderP
 	if rpcResponseHeaderProto.ClientId != nil {
 		if !bytes.Equal(SASL_RPC_DUMMY_CLIENT_ID, headerClientId) {
 			klog.Warningf("Incorrect clientId: %v", headerClientId)
-			return errors.New("Incorrect clientId")
+			return errors.New("incorrect clientId")
 		}
 	}
 	return nil
 }
 
-func negotiateSimpleTokenAuth(client *Client, con *connection) error {
-	var saslNegotiateState hadoop_common.RpcSaslProto_SaslState = hadoop_common.RpcSaslProto_NEGOTIATE
-	var saslNegotiateMessage hadoop_common.RpcSaslProto = hadoop_common.RpcSaslProto{State: &saslNegotiateState}
-	var saslResponseMessage *hadoop_common.RpcSaslProto
-	var err error
+func createSaslReply(state hadoop_common.RpcSaslProto_SaslState, token []byte) *hadoop_common.RpcSaslProto {
+	return &hadoop_common.RpcSaslProto{
+		State: &state,
+		Token: token,
+	}
+}
 
-	//send a SASL negotiation request
-	if err = sendSaslMessage(client, con, &saslNegotiateMessage); err != nil {
-		klog.Warningf("failed to send SASL NEGOTIATE message!")
-		return err
+// TODO implement this
+func isValidAuthType(auth *hadoop_common.RpcSaslProto_SaslAuth) bool {
+	return true
+}
+
+func selectSaslClient(client *Client, auths []*hadoop_common.RpcSaslProto_SaslAuth) (*hadoop_common.RpcSaslProto_SaslAuth, SASLClient, error) {
+	var selectedAuth *hadoop_common.RpcSaslProto_SaslAuth
+	var saslClient SASLClient
+	var switchToSimple bool
+
+	for _, auth := range auths {
+		if !isValidAuthType(auth) {
+			continue
+		}
+
+		authMethod := yarnauth.ConvertAuthProtoToAuthMethod(auth)
+		if authMethod == yarnauth.AUTH_SIMPLE {
+			switchToSimple = true
+		} else {
+			saslClient = createSaslClient(client, auth, authMethod)
+			if saslClient == nil {
+				continue
+			}
+		}
+		selectedAuth = auth
+		break
 	}
 
-	//get a response with supported mehcanisms/challenge
-	if saslResponseMessage, err = receiveSaslMessage(client, con); err != nil {
-		klog.Warningf("failed to receive SASL NEGOTIATE response!")
-		return err
+	if saslClient == nil && !switchToSimple {
+		return nil, nil, fmt.Errorf("client cannot authenticate via %v", auths)
+	}
+	return selectedAuth, saslClient, nil
+}
+
+func createSaslClient(c *Client, auth *hadoop_common.RpcSaslProto_SaslAuth, authMethod yarnauth.AuthMethod) SASLClient {
+	switch authMethod {
+	case yarnauth.AUTH_KERBEROS:
+		keytabFilePath := c.UGI.GetKeytabFilePath()
+		principal := c.UGI.GetPrincipal()
+		return CreateKerberosClient(keytabFilePath, principal)
+	case yarnauth.AUTH_TOKEN:
+		token, found := findUsableTokenForService(c.ServerAddress)
+		if !found {
+			klog.Info("not found token")
+			return nil
+		}
+		return CreateTokenAuth(token, auth)
 	}
 
-	var auths []*hadoop_common.RpcSaslProto_SaslAuth = saslResponseMessage.GetAuths()
+	return nil
+}
 
-	if numAuths := len(auths); numAuths <= 0 {
-		klog.Warningf("No supported auth mechanisms!")
-		return errors.New("No supported auth mechanisms!")
-	}
-
-	//for now we only support auth when TOKEN/DIGEST-MD5 is the first/only
-	//supported auth mechanism
-	var auth *hadoop_common.RpcSaslProto_SaslAuth = auths[0]
-
-	if !(auth.GetMethod() == "TOKEN" && auth.GetMechanism() == "DIGEST-MD5") {
-		klog.Warningf("yarnauth only supports TOKEN/DIGEST-MD5 auth!")
-		return errors.New("yarnauth only supports TOKEN/DIGEST-MD5 auth!")
-	}
-
-	method := auth.GetMethod()
-	mechanism := auth.GetMechanism()
-	protocol := auth.GetProtocol()
-	serverId := auth.GetServerId()
-	challenge := auth.GetChallenge()
-
-	//TODO: token/service mapping + token selection based on type/service
-	//we wouldn't have gotten this far if there wasn't at least one available token.
-	userToken, _ := findUsableTokenForService(client.ServerAddress)
-	response, err := security.GetDigestMD5ChallengeResponse(protocol, serverId, challenge, userToken)
-
-	if err != nil {
-		klog.Warningf("failed to get challenge response! %v", err)
-		return err
-	}
-
-	saslInitiateState := hadoop_common.RpcSaslProto_INITIATE
-	authSend := hadoop_common.RpcSaslProto_SaslAuth{Method: &method, Mechanism: &mechanism,
-		Protocol: &protocol, ServerId: &serverId}
-	authsSendArray := []*hadoop_common.RpcSaslProto_SaslAuth{&authSend}
-	saslInitiateMessage := hadoop_common.RpcSaslProto{State: &saslInitiateState,
-		Token: []byte(response), Auths: authsSendArray}
-
-	//send a SASL inititate request
-	if err = sendSaslMessage(client, con, &saslInitiateMessage); err != nil {
-		klog.Warningf("failed to send SASL INITIATE message!")
-		return err
-	}
-
-	//get a response with supported mehcanisms/challenge
-	if saslResponseMessage, err = receiveSaslMessage(client, con); err != nil {
-		klog.Warningf("failed to read response to SASL INITIATE response!")
-		return err
-	}
-
-	if saslResponseMessage.GetState() != hadoop_common.RpcSaslProto_SUCCESS {
-		klog.Warningf("expected SASL SUCCESS response!")
-		return errors.New("expected SASL SUCCESS response!")
-	}
-
-	klog.V(4).Infof("Successfully completed SASL negotiation!")
-
-	return nil //errors.New("abort here")
+type SASLClient interface {
+	EvaluateChallenge([]byte) ([]byte, error)
 }

--- a/pkg/yarn/client/ipc/client.go
+++ b/pkg/yarn/client/ipc/client.go
@@ -226,6 +226,7 @@ func setupConnection(c *Client) (*connection, error) {
 	// close the connection if we fail to setup the connection
 	defer func() {
 		if err != nil {
+			// nolint:errcheck
 			conn.Close()
 		}
 	}()
@@ -253,6 +254,7 @@ func setupConnection(c *Client) (*connection, error) {
 		if fd, err = tcpConn.File(); err != nil {
 			return nil, err
 		}
+		// nolint:errcheck
 		defer fd.Close()
 
 		/*
@@ -336,7 +338,7 @@ func saslConnect(client *Client, con *connection) (*yarnauth.AuthMethod, error) 
 			if saslClient == nil {
 				authMethod = yarnauth.AUTH_SIMPLE
 			} else {
-				// ignore error
+				// nolint:errcheck
 				saslClient.EvaluateChallenge(challengeToken)
 			}
 			done = true

--- a/pkg/yarn/client/ipc/kerberos.go
+++ b/pkg/yarn/client/ipc/kerberos.go
@@ -1,3 +1,20 @@
+/*
+Copyright 2013 The Cloudera Inc.
+Copyright 2023 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ipc
 
 import (

--- a/pkg/yarn/client/ipc/kerberos.go
+++ b/pkg/yarn/client/ipc/kerberos.go
@@ -1,0 +1,194 @@
+package ipc
+
+import (
+	"encoding/binary"
+	"os"
+	"strings"
+
+	"github.com/jcmturner/gofork/encoding/asn1"
+	"github.com/jcmturner/gokrb5/v8/asn1tools"
+	krb5client "github.com/jcmturner/gokrb5/v8/client"
+	krb5config "github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/gssapi"
+	"github.com/jcmturner/gokrb5/v8/iana/chksumtype"
+	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
+	"github.com/jcmturner/gokrb5/v8/keytab"
+	"github.com/jcmturner/gokrb5/v8/messages"
+	"github.com/jcmturner/gokrb5/v8/types"
+
+	"k8s.io/klog/v2"
+)
+
+type GSSAPIKerberosAuth struct {
+	ticket   messages.Ticket
+	encKey   types.EncryptionKey
+	username string
+	realm    string
+	cname    types.PrincipalName
+	step     int
+}
+
+const DefaultKrb5Config = "/etc/krb5.conf"
+
+func CreateKerberosClient(keytabFilePath, principal string) *GSSAPIKerberosAuth {
+	krb5ConfigFile := os.Getenv("KRB5_CONFIG")
+	if krb5ConfigFile == "" {
+		krb5ConfigFile = DefaultKrb5Config
+	}
+	cfg, err := krb5config.Load(krb5ConfigFile)
+	if err != nil {
+		klog.Errorf("failed to load krb5 config: %v", err)
+		return nil
+	}
+
+	kt, err := keytab.Load(keytabFilePath)
+	if err != nil {
+		klog.Error("failed to load keytab: %v", err)
+		return nil
+	}
+
+	// yarn.resourcemanager.principal
+	// eg: yarn/master.example.com@EXAMPLE.COM
+	parts := strings.Split(principal, "@")
+	username, realm := parts[0], parts[1]
+	krbclient := krb5client.NewWithKeytab(username, realm, kt, cfg)
+
+	if err := krbclient.Login(); err != nil {
+		klog.Errorf("kerberos client error: %v", err)
+		return nil
+	}
+
+	ticket, encKey, err := krbclient.GetServiceTicket(username)
+	if err != nil {
+		klog.Errorf("error getting Kerberos service ticket : %v", err)
+		return nil
+	}
+
+	kerberosClient := &GSSAPIKerberosAuth{
+		username: username,
+		realm:    krbclient.Credentials.Domain(),
+		cname:    krbclient.Credentials.CName(),
+
+		ticket: ticket,
+		encKey: encKey,
+	}
+	// Set the initial step to GSS_API_INITIAL
+	kerberosClient.step = GSS_API_INITIAL
+	return kerberosClient
+}
+
+// copy from https://github.com/IBM/sarama/sarama/kerberos_client.go initSecContext
+func (krbAuth *GSSAPIKerberosAuth) EvaluateChallenge(token []byte) ([]byte, error) {
+	switch krbAuth.step {
+	case GSS_API_INITIAL:
+		aprBytes, err := krbAuth.createKrb5Token(krbAuth.realm, krbAuth.cname, krbAuth.ticket, krbAuth.encKey)
+		if err != nil {
+			return nil, err
+		}
+
+		krbAuth.step = GSS_API_VERIFY
+		return krbAuth.appendGSSAPIHeader(aprBytes)
+	case GSS_API_VERIFY:
+		wrapTokenReq := gssapi.WrapToken{}
+		if err := wrapTokenReq.Unmarshal(token, true); err != nil {
+			return nil, err
+		}
+		// Validate response
+		isValid, err := wrapTokenReq.Verify(krbAuth.encKey, keyusage.GSSAPI_ACCEPTOR_SEAL)
+		if !isValid {
+			return nil, err
+		}
+
+		wrapTokenResponse, err := gssapi.NewInitiatorWrapToken(wrapTokenReq.Payload, krbAuth.encKey)
+		if err != nil {
+			return nil, err
+		}
+		krbAuth.step = GSS_API_FINISH
+		return wrapTokenResponse.Marshal()
+	}
+	return nil, nil
+}
+
+// NOTE: copy from https://github.com/IBM/sarama/blob/main/gssapi_kerberos.go
+const (
+	TOK_ID_KRB_AP_REQ   = 256
+	GSS_API_GENERIC_TAG = 0x60
+
+	KRB5_USER_AUTH   = 1
+	KRB5_KEYTAB_AUTH = 2
+	KRB5_CCACHE_AUTH = 3
+
+	GSS_API_INITIAL = 1
+	GSS_API_VERIFY  = 2
+	GSS_API_FINISH  = 3
+)
+
+func (krbAuth *GSSAPIKerberosAuth) newAuthenticatorChecksum() []byte {
+	a := make([]byte, 24)
+	flags := []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}
+	binary.LittleEndian.PutUint32(a[:4], 16)
+	for _, i := range flags {
+		f := binary.LittleEndian.Uint32(a[20:24])
+		f |= uint32(i)
+		binary.LittleEndian.PutUint32(a[20:24], f)
+	}
+	return a
+}
+
+/*
+*
+* Construct Kerberos AP_REQ package, conforming to RFC-4120
+* https://tools.ietf.org/html/rfc4120#page-84
+*
+ */
+func (krbAuth *GSSAPIKerberosAuth) createKrb5Token(
+	domain string, cname types.PrincipalName,
+	ticket messages.Ticket,
+	sessionKey types.EncryptionKey) ([]byte, error) {
+	auth, err := types.NewAuthenticator(domain, cname)
+	if err != nil {
+		return nil, err
+	}
+	auth.Cksum = types.Checksum{
+		CksumType: chksumtype.GSSAPI,
+		Checksum:  krbAuth.newAuthenticatorChecksum(),
+	}
+	APReq, err := messages.NewAPReq(
+		ticket,
+		sessionKey,
+		auth,
+	)
+	if err != nil {
+		return nil, err
+	}
+	aprBytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(aprBytes, TOK_ID_KRB_AP_REQ)
+	tb, err := APReq.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	aprBytes = append(aprBytes, tb...)
+	return aprBytes, nil
+}
+
+/*
+*
+*	Append the GSS-API header to the payload, conforming to RFC-2743
+*	Section 3.1, Mechanism-Independent Token Format
+*
+*	https://tools.ietf.org/html/rfc2743#page-81
+*
+*	GSSAPIHeader + <specific mechanism payload>
+*
+ */
+func (krbAuth *GSSAPIKerberosAuth) appendGSSAPIHeader(payload []byte) ([]byte, error) {
+	oidBytes, err := asn1.Marshal(gssapi.OIDKRB5.OID())
+	if err != nil {
+		return nil, err
+	}
+	tkoLengthBytes := asn1tools.MarshalLengthBytes(len(oidBytes) + len(payload))
+	GSSHeader := append([]byte{GSS_API_GENERIC_TAG}, tkoLengthBytes...)
+	GSSHeader = append(GSSHeader, oidBytes...)
+	GSSPackage := append(GSSHeader, payload...)
+	return GSSPackage, nil
+}

--- a/pkg/yarn/client/ipc/kerberos.go
+++ b/pkg/yarn/client/ipc/kerberos.go
@@ -1,4 +1,6 @@
 /*
+Copyright (c) 2013 Shopify
+Copyright (c) 2023 IBM Corporation
 Copyright 2013 The Cloudera Inc.
 Copyright 2023 The Koordinator Authors.
 

--- a/pkg/yarn/client/ipc/token.go
+++ b/pkg/yarn/client/ipc/token.go
@@ -1,3 +1,20 @@
+/*
+Copyright 2013 The Cloudera Inc.
+Copyright 2023 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ipc
 
 import (

--- a/pkg/yarn/client/ipc/token.go
+++ b/pkg/yarn/client/ipc/token.go
@@ -1,0 +1,28 @@
+package ipc
+
+import (
+	hadoop_common "github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/proto/hadoopcommon"
+	"github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/security"
+)
+
+type TokenAuth struct {
+	userToken *hadoop_common.TokenProto
+	protocol  *string
+	serverID  *string
+}
+
+var _ SASLClient = &TokenAuth{}
+
+func CreateTokenAuth(token *hadoop_common.TokenProto, auth *hadoop_common.RpcSaslProto_SaslAuth) *TokenAuth {
+	return &TokenAuth{
+		userToken: token,
+		protocol:  auth.Protocol,
+		serverID:  auth.ServerId,
+	}
+}
+
+func (t *TokenAuth) EvaluateChallenge(challenge []byte) ([]byte, error) {
+	response, err := security.GetDigestMD5ChallengeResponse(*t.protocol, *t.serverID, challenge, t.userToken)
+
+	return []byte(response), err
+}

--- a/pkg/yarn/config/configuration.go
+++ b/pkg/yarn/config/configuration.go
@@ -120,6 +120,7 @@ func NewConfigurationResources(hadoopConfDir string, resources []Resource, prefi
 			klog.Warningf("Couldn't read resource: ", err)
 			return nil, err
 		}
+		// nolint:errcheck
 		defer conf.Close()
 
 		// Parse


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

support kerberos auth

tested:
- [x] no auth
- [x] kerberos with keytab
- [ ] token

<!--
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

kerberos auth example

next we suppose you have a hadoop cluster with kerberos auth, refer https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SecureMode.html
```bash
$ mkdir conf
$ cp /path/to/yarn-site.xml conf
$ cp /path/to/core-site.xml conf

# conf example
$ cat ./conf/core-site.xml
...
  <property>
    <name>hadoop.security.authentication</name>
    <value>kerberos</value>
  </property>

  <property>
    <name>hadoop.security.authorization</name>
    <value>true</value>
  </property>
...

$ cat ./conf/yarn-site.xml
...
  <property>
    <name>yarn.resourcemanager.principal</name>
    <value>bob/hadoop@example.hadoop</value>
  </property>

  <property>
    <name>yarn.resourcemanager.keytab</name>
    <value>/etc/hadoop/conf/example.keytab</value>
  </property>

...

$ env HADOOP_CONF_DIR=./conf go run pkg/yarn/client/examples/rm-get-cluster-nodes-with-ha/main.go
# example output
...
2025/04/15 20:33:17 node nodeId:{host:"x.x.x.x" port:xx} httpAddress:"x.x.x.x:xx" rackName:"/default-rack" used:{memory:0 virtual_cores:0 resource_value_map:{key:"memory-mb" value:0 units:"Mi" type:COUNTABLE} resource_value_map:{key:"vcores" value:0 units:"" type:COUNTABLE}} capability:{memory:24491 virtual_cores:5 resource_value_map:{key:"memory-mb" value:24491 units:"Mi" type:COUNTABLE} resource_value_map:{key:"vcores" value:5 units:"" type:COUNTABLE}} node_state:NS_LOST health_report:"" last_health_report_time:1744256666099 containers_utilization:{pmem:0 vmem:0 cpu:0} node_utilization:{pmem:14913 vmem:14913 cpu:12.52712}
2025/04/15 20:33:17 used  x.x.x.x:xx
2025/04/15 20:33:17 used virtual cpu 0
2025/04/15 20:33:17 used memory 0
2025/04/15 20:33:17 used resource map [key:"memory-mb" value:0 units:"Mi" type:COUNTABLE key:"vcores" value:0 units:"" type:COUNTABLE]
...
```

### Ⅱ. Does this pull request fix one issue?

<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### Ⅲ. Describe how to verify it

### Ⅳ. Special notes for reviews

### V. Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `make test`
