### PR TITLE
kerberos with hadoop qop authentication

### DIFF
--- a/config/operator-kerberos/configmap.yaml
+++ b/config/operator-kerberos/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: yarn-config
+  namespace: koordinator-system
+data:
+  yarn-site.xml: |
+    <configuration>
+        <property>
+            <name>yarn.resourcemanager.admin.address</name>
+            <value>0.0.0.0:8033</value>
+        </property>
+        <property>
+            <name>yarn.resourcemanager.address</name>
+            <value>0.0.0.0:8032</value>
+        </property>
+    </configuration>
+  core-site.xml: |
+    <configuration>
+    </configuration>

--- a/config/operator-kerberos/kerberos-config.yaml
+++ b/config/operator-kerberos/kerberos-config.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kerberos-config
+  namespace: arco-system
+data:
+  krb5.conf: |
+
+    # Configuration snippets may be placed in this directory as well
+    includedir /etc/krb5.conf.d/
+    
+    [logging]
+     default = FILE:/var/log/krb5libs.log
+     kdc = FILE:/var/log/krb5kdc.log
+     admin_server = FILE:/var/log/kadmind.log
+    
+    [libdefaults]
+     udp_preference_limit = 1
+     dns_lookup_realm = false
+     ticket_lifetime = 24h
+     renew_lifetime = 7d
+     forwardable = true
+     rdns = false
+    # pkinit_anchors = FILE:/etc/pki/tls/certs/ca-bundle.crt
+     default_realm = EXAMPLE.COM
+    # default_ccache_name = KEYRING:persistent:%{uid}
+    
+    [realms]
+     EXAMPLE.COM = {
+      kdc = 127.0.0.1
+      admin_server = 127.0.0.1
+     }
+    
+    [domain_realm]
+     .example.com = EXAMPLE.COM
+     example.com = EXAMPLE.COM

--- a/config/operator-kerberos/role.yaml
+++ b/config/operator-kerberos/role.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: koord-yarn-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: koordinator-system
+  name: koord-yarn-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: koord-yarn-operator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: koord-yarn-operator
+subjects:
+  - kind: ServiceAccount
+    name: koord-yarn-operator
+    namespace: koordinator-system

--- a/config/operator-kerberos/secret.yaml
+++ b/config/operator-kerberos/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yarn-operator-keytab
+  namespace: arco-system
+type: Opaque
+data:
+  yarn.keytab: "Base64 Encoded Keytab File"

--- a/config/operator-kerberos/yarn-operator.yaml
+++ b/config/operator-kerberos/yarn-operator.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: koord-yarn-operator
+  namespace: arco-system
+  labels:
+    koord-app: koord-yarn-operator
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      koord-app: koord-yarn-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        koord-app: koord-yarn-operator
+    spec:
+      containers:
+        - args:
+            - --enable-leader-election
+            - --metrics-addr=:8080
+            - --logtostderr=true
+            - --leader-election-namespace=arco-system
+            - --v=4
+            - --sync-period=0
+          command:
+            - /koord-yarn-operator
+          image: reg.docker.alibaba-inc.com/antkoord/yarn-operator:20251225141615_kerberos_4791c306
+          imagePullPolicy: IfNotPresent
+          name: yarn-operator
+          env:
+            - name: HADOOP_CONF_DIR
+              value: /etc/hadoop-conf
+            - name: ENABLE_KERBEROS
+              value: "true"
+            - name: KRB5_CLIENT_USERNAME
+              value: yarn-operator
+            - name: KRB5_CLIENT_REALM
+              value: EXAMPLE.COM
+            - name: KRB5_CONF_PATH
+              value: /etc/krb5.conf
+            - name: KRB5_KEYTAB_PATH
+              value: /etc/security/keytabs/yarn.keytab
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: yarn-config-volume
+              mountPath: /etc/hadoop-conf
+            - name: kerberos-config
+              mountPath: /etc/krb5.conf
+              subPath: krb5.conf
+            - name: yarn-keytab
+              mountPath: /etc/security/keytabs/yarn.keytab
+              subPath: yarn.keytab
+      volumes:
+        - name: yarn-config-volume
+          configMap:
+            name: yarn-config
+        - name: kerberos-config
+          configMap:
+            name: kerberos-config
+            items:
+              - key: krb5.conf
+                path: krb5.conf
+        - name: yarn-keytab
+          secret:
+            secretName: yarn-operator-keytab
+      hostNetwork: false
+      terminationGracePeriodSeconds: 10
+      restartPolicy: Always
+      serviceAccountName: koord-yarn-operator
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: koord-app
+                      operator: In
+                      values:
+                        - koord-yarn-operator
+                topologyKey: kubernetes.io/hostname
+              weight: 100

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/koordinator-sh/yarn-copilot
 go 1.19
 
 require (
+	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/koordinator-sh/koordinator v1.3.0
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/spf13/pflag v1.0.5
@@ -118,8 +119,13 @@ require (
 	github.com/google/cadvisor v0.44.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 // indirect
+	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hodgesds/perf-utils v0.5.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
+	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
+	github.com/jcmturner/gofork v1.7.6 // indirect
+	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -471,6 +471,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
@@ -505,6 +507,9 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
+github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -532,6 +537,18 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ionos-cloud/sdk-go/v6 v6.1.3 h1:vb6yqdpiqaytvreM0bsn2pXw+1YDvEk2RKSmBAQvgDQ=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
+github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
+github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
+github.com/jcmturner/dnsutils/v2 v2.0.0 h1:lltnkeZGL0wILNvrNiVCR6Ro5PGU/SeBvVO/8c/iPbo=
+github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=
+github.com/jcmturner/gofork v1.7.6 h1:QH0l3hzAU1tfT3rZCnW5zXl+orbkNMMRGJfdJjHVETg=
+github.com/jcmturner/gofork v1.7.6/go.mod h1:1622LH6i/EZqLloHfE7IeZ0uEJwMSUyQ/nDd82IeqRo=
+github.com/jcmturner/goidentity/v6 v6.0.1 h1:VKnZd2oEIMorCTsFBnJWbExfNN7yZr3EhJAxwOkZg6o=
+github.com/jcmturner/goidentity/v6 v6.0.1/go.mod h1:X1YW3bgtvwAXju7V3LCIMpY0Gbxyjn/mY9zx4tFonSg=
+github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh687T8=
+github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
+github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
+github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -852,6 +869,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/pkg/yarn/client/ipc/client.go
+++ b/pkg/yarn/client/ipc/client.go
@@ -20,6 +20,7 @@ package ipc
 import (
 	"bufio"
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -163,6 +164,9 @@ func getConnection(c *Client, connectionId *connection_id) (*connection, error) 
 		klog.V(4).Infof("found token for service: %s", c.ServerAddress)
 		authProtocol = yarnauth.AUTH_PROTOCOL_SASL
 	}
+	if IsEnableKerberos() {
+		authProtocol = yarnauth.AUTH_PROTOCOL_SASL
+	}
 
 	err = writeConnectionHeader(con, authProtocol)
 	if err != nil {
@@ -170,11 +174,18 @@ func getConnection(c *Client, connectionId *connection_id) (*connection, error) 
 	}
 
 	if authProtocol == yarnauth.AUTH_PROTOCOL_SASL {
-		klog.V(4).Infof("attempting SASL negotiation.")
-
-		if err = negotiateSimpleTokenAuth(c, con); err != nil {
-			klog.Warningf("failed to complete SASL negotiation!")
-			return nil, err
+		if IsEnableKerberos() {
+			klog.Infof("will negotiate kerberos auth")
+			if err := negotiateKerberosAuth(c, con); err != nil {
+				con.con.Close()
+				klog.Errorf("failed to negotiate kerberos auth: %v", err)
+				return nil, err
+			}
+		} else {
+			if err := negotiateSimpleTokenAuth(c, con); err != nil {
+				con.con.Close()
+				return nil, err
+			}
 		}
 
 	} else {
@@ -479,13 +490,18 @@ func readDelimited(rawData []byte, msg proto.Message) (int, error) {
 }
 
 func (c *Client) checkRpcHeader(rpcResponseHeaderProto *hadoop_common.RpcResponseHeaderProto) error {
+	if rpcResponseHeaderProto.GetStatus() != hadoop_common.RpcResponseHeaderProto_SUCCESS {
+		return nil
+	}
+
+	headerClientId := rpcResponseHeaderProto.ClientId
+	if headerClientId == nil || len(headerClientId) < 16 {
+		return errors.New("invalid or missing clientId in RPC response")
+	}
+
 	var callClientId = [16]byte(*c.ClientId)
-	var headerClientId = rpcResponseHeaderProto.ClientId
-	if rpcResponseHeaderProto.ClientId != nil {
-		if !bytes.Equal(callClientId[0:16], headerClientId[0:16]) {
-			klog.Warningf("Incorrect clientId: %v", headerClientId)
-			return errors.New("Incorrect clientId")
-		}
+	if !bytes.Equal(callClientId[:], headerClientId[:16]) {
+		return errors.New("incorrect clientId")
 	}
 	return nil
 }
@@ -494,43 +510,33 @@ func sendSaslMessage(c *Client, conn *connection, message *hadoop_common.RpcSasl
 	saslRpcHeaderProto := hadoop_common.RpcRequestHeaderProto{RpcKind: &yarnauth.RPC_PROTOCOL_BUFFFER,
 		RpcOp:      &yarnauth.RPC_FINAL_PACKET,
 		CallId:     &SASL_RPC_CALL_ID,
-		ClientId:   SASL_RPC_DUMMY_CLIENT_ID,
+		ClientId:   (*c.ClientId)[:],
 		RetryCount: &SASL_RPC_INVALID_RETRY_COUNT}
 
 	saslRpcHeaderProtoBytes, err := proto.Marshal(&saslRpcHeaderProto)
-
 	if err != nil {
 		klog.Warningf("proto.Marshal(&saslRpcHeaderProto) %v", err)
 		return err
 	}
-
 	saslRpcMessageProtoBytes, err := proto.Marshal(message)
-
 	if err != nil {
 		klog.Warningf("proto.Marshal(saslMessage) %v", err)
 		return err
 	}
 
-	totalLength := len(saslRpcHeaderProtoBytes) + sizeVarint(len(saslRpcHeaderProtoBytes)) + len(saslRpcMessageProtoBytes) + sizeVarint(len(saslRpcMessageProtoBytes))
-	var tLen int32 = int32(totalLength)
-	if err := conn.con.SetDeadline(time.Now().Add(rwDefaultTimeout)); err != nil {
+	fullHeader := encodeDelimited(saslRpcHeaderProtoBytes)
+	fullMessage := encodeDelimited(saslRpcMessageProtoBytes)
+	totalLen := int32(len(fullHeader) + len(fullMessage))
+
+	lenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBuf, uint32(totalLen))
+	if _, err := conn.con.Write(lenBuf); err != nil {
 		return err
 	}
-	if totalLengthBytes, err := yarnauth.ConvertFixedToBytes(tLen); err != nil {
-		klog.Warningf("ConvertFixedToBytes(totalLength) %v", err)
-		return err
-	} else {
-		if _, err := conn.con.Write(totalLengthBytes); err != nil {
-			klog.Warningf("conn.con.Write(totalLengthBytes) %v", err)
-			return err
-		}
-	}
-	if err := writeDelimitedBytes(conn, saslRpcHeaderProtoBytes); err != nil {
-		klog.Warningf("writeDelimitedBytes(conn, saslRpcHeaderProtoBytes) %v", err)
+	if _, err := conn.con.Write(fullHeader); err != nil {
 		return err
 	}
-	if err := writeDelimitedBytes(conn, saslRpcMessageProtoBytes); err != nil {
-		klog.Warningf("writeDelimitedBytes(conn, saslRpcMessageProtoBytes) %v", err)
+	if _, err := conn.con.Write(fullMessage); err != nil {
 		return err
 	}
 
@@ -556,9 +562,8 @@ func receiveSaslMessage(c *Client, conn *connection) (*hadoop_common.RpcSaslProt
 	}
 
 	var responseBytes []byte = make([]byte, totalLength)
-
-	if _, err := conn.con.Read(responseBytes); err != nil {
-		klog.Warningf("conn.con.Read(totalLengthBytes) %v", err)
+	if _, err := io.ReadFull(conn.con, responseBytes); err != nil {
+		klog.Warningf("failed to read full sasl response: %v", err)
 		return nil, err
 	}
 
@@ -691,4 +696,10 @@ func negotiateSimpleTokenAuth(client *Client, con *connection) error {
 	klog.V(4).Infof("Successfully completed SASL negotiation!")
 
 	return nil //errors.New("abort here")
+}
+
+func encodeDelimited(data []byte) []byte {
+	prefix := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(prefix, uint64(len(data)))
+	return append(prefix[:n], data...)
 }

--- a/pkg/yarn/client/ipc/client_test.go
+++ b/pkg/yarn/client/ipc/client_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ipc
 
 import (

--- a/pkg/yarn/client/ipc/client_test.go
+++ b/pkg/yarn/client/ipc/client_test.go
@@ -1,0 +1,31 @@
+package ipc
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeDelimited(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", []byte{}},
+		{"short data", []byte{0x01, 0x02, 0x03}},
+		{"long data", make([]byte, 300)},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			encoded := encodeDelimited(c.data)
+
+			// 读取前缀长度
+			length, n := binary.Uvarint(encoded)
+			assert.Equal(t, uint64(len(c.data)), length)
+			assert.Equal(t, len(encoded), n+len(c.data))
+			assert.Equal(t, c.data, encoded[n:])
+		})
+	}
+}

--- a/pkg/yarn/client/ipc/kerberos.go
+++ b/pkg/yarn/client/ipc/kerberos.go
@@ -1,3 +1,20 @@
+/*
+Copyright 2013 The Cloudera Inc.
+Copyright 2023 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ipc
 
 import (

--- a/pkg/yarn/client/ipc/kerberos.go
+++ b/pkg/yarn/client/ipc/kerberos.go
@@ -262,7 +262,7 @@ func generateGssapiKerberosToken(krb5Config KerberosConf, spn string) ([]byte, *
 	payload := append(oid, tokenID...)
 	payload = append(payload, apReqBytes...)
 
-	// 构造 Application Construct Tag (0x60)
+	// Build Application Construct Tag (0x60)
 	var finalToken []byte
 	finalToken = append(finalToken, 0x60)
 	finalToken = append(finalToken, encodeASN1Length(len(payload))...)

--- a/pkg/yarn/client/ipc/kerberos.go
+++ b/pkg/yarn/client/ipc/kerberos.go
@@ -1,5 +1,4 @@
 /*
-Copyright 2013 The Cloudera Inc.
 Copyright 2023 The Koordinator Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/yarn/client/ipc/kerberos.go
+++ b/pkg/yarn/client/ipc/kerberos.go
@@ -1,0 +1,268 @@
+package ipc
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/jcmturner/gokrb5/v8/client"
+	"github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/gssapi"
+	"github.com/jcmturner/gokrb5/v8/iana/chksumtype"
+	"github.com/jcmturner/gokrb5/v8/iana/nametype"
+	"github.com/jcmturner/gokrb5/v8/keytab"
+	"github.com/jcmturner/gokrb5/v8/messages"
+	"github.com/jcmturner/gokrb5/v8/types"
+	"k8s.io/klog/v2"
+
+	hadoop_common "github.com/koordinator-sh/yarn-copilot/pkg/yarn/apis/proto/hadoopcommon"
+)
+
+const (
+	EnvEnableKerberos = "ENABLE_KERBEROS"
+	EnvKrb5ConfPath   = "KRB5_CONF_PATH"
+	EnvKeytabPath     = "KRB5_KEYTAB_PATH"
+	EnvClientUserName = "KRB5_CLIENT_USERNAME"
+	EnvClientRealm    = "KRB5_CLIENT_REALM"
+
+	DefaultKrb5ConfPath   = "/etc/krb5.conf"
+	DefaultKeytabPath     = "/etc/security/keytabs/yarn.keytab"
+	DefaultClientUserName = "yarn-operator"
+	DefaultRealm          = "EXAMPLE.COM"
+)
+
+type KerberosConf struct {
+	Krb5ConfPath   string
+	KeytabPath     string
+	ClientUserName string
+	ClientRealm    string
+}
+
+func IsEnableKerberos() bool {
+	if v, ok := os.LookupEnv(EnvEnableKerberos); ok {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "1", "true", "yes", "y", "on", "TRUE":
+			return true
+		case "0", "false", "no", "n", "off", "FALSE":
+			return false
+		}
+	}
+	return false
+}
+
+func GetKerberosConf() KerberosConf {
+	conf := KerberosConf{
+		Krb5ConfPath:   DefaultKrb5ConfPath,
+		KeytabPath:     DefaultKeytabPath,
+		ClientUserName: DefaultClientUserName,
+		ClientRealm:    DefaultRealm,
+	}
+
+	if v, ok := os.LookupEnv(EnvKrb5ConfPath); ok && v != "" {
+		conf.Krb5ConfPath = v
+	}
+
+	if v, ok := os.LookupEnv(EnvKeytabPath); ok && v != "" {
+		conf.KeytabPath = v
+	}
+
+	if v, ok := os.LookupEnv(EnvClientUserName); ok && v != "" {
+		conf.ClientUserName = v
+	}
+
+	if v, ok := os.LookupEnv(EnvClientRealm); ok && v != "" {
+		conf.ClientRealm = v
+	}
+
+	return conf
+}
+
+func negotiateKerberosAuth(client *Client, con *connection) error {
+	// SASL NEGOTIATE
+	negState := hadoop_common.RpcSaslProto_NEGOTIATE
+	if err := sendSaslMessage(client, con, &hadoop_common.RpcSaslProto{State: &negState}); err != nil {
+		return err
+	}
+
+	resp, err := receiveSaslMessage(client, con)
+	if err != nil {
+		return err
+	}
+
+	var krbAuth *hadoop_common.RpcSaslProto_SaslAuth
+	for i, a := range resp.Auths {
+		klog.Infof("Server support auth [%d]: Method=%s, Mechanism=%s, Protocol=%s, ServerID=%s", i, a.GetMethod(), a.GetMechanism(), a.GetProtocol(), a.GetServerId())
+		if a.GetMethod() == "KERBEROS" && a.GetMechanism() == "GSSAPI" {
+			krbAuth = a
+		}
+	}
+	if krbAuth == nil {
+		klog.Errorf("kerberos with gssapi is not supported")
+		return fmt.Errorf("kerberos with gssapi is not supported")
+	}
+
+	// Kerberos Handshake
+	spn := fmt.Sprintf("%s/%s", krbAuth.GetProtocol(), krbAuth.GetServerId())
+	krb5Conf := GetKerberosConf()
+	token, sessionKey, err := generateGssapiKerberosToken(krb5Conf, spn)
+	if err != nil {
+		klog.Errorf("failed to generate gss-api kerberos token: %v", err)
+		return err
+	}
+
+	// SASL INITIATE
+	saslInitiateState := hadoop_common.RpcSaslProto_INITIATE
+	saslInitiateMessage := hadoop_common.RpcSaslProto{
+		State: &saslInitiateState,
+		Token: token,
+		Auths: []*hadoop_common.RpcSaslProto_SaslAuth{krbAuth},
+	}
+
+	if err = sendSaslMessage(client, con, &saslInitiateMessage); err != nil {
+		klog.Errorf("failed to send sasl initiate message: %v", err)
+		return err
+	}
+
+	saslResponseMessage, err := receiveSaslMessage(client, con)
+	if err != nil {
+		klog.Errorf("failed to receive sasl message: %v", err)
+		return err
+	}
+
+	// SASL CHALLENGE
+	if saslResponseMessage.GetState() == hadoop_common.RpcSaslProto_CHALLENGE {
+		// check hadoop qop
+		var serverWrapToken gssapi.WrapToken
+		if err := serverWrapToken.Unmarshal(saslResponseMessage.GetToken(), true); err != nil {
+			klog.Errorf("failed to unmarshal server challenge token: %v", err)
+			return err
+		}
+		serverQOP := serverWrapToken.Payload[0]
+		if serverWrapToken.Payload[0] > 0x01 {
+			klog.Errorf("Server requires QOP %d (Integrity/Privacy), but this client only supports 1 (Authentication)", serverQOP)
+			return fmt.Errorf("unsupported SASL QOP level: %d", serverQOP)
+		}
+
+		rawPayload := []byte{0x01, 0x00, 0x00, 0x00} // require hadoop qop Authentication
+		authzID := []byte(fmt.Sprintf("%s@%s", krb5Conf.ClientUserName, krb5Conf.ClientRealm))
+		fullPayload := append(rawPayload, authzID...)
+
+		wrapToken, err := gssapi.NewInitiatorWrapToken(fullPayload, *sessionKey)
+		if err != nil {
+			klog.Errorf("failed to wrap challenge token: %v", err)
+			return err
+		}
+
+		finalBytes, err := wrapToken.Marshal()
+		if err != nil {
+			klog.Errorf("failed to marshal challenge token: %v", err)
+			return err
+		}
+
+		// SASL RESPONSE
+		saslResponseState := hadoop_common.RpcSaslProto_RESPONSE
+		saslResponseMessageToSend := hadoop_common.RpcSaslProto{
+			State: &saslResponseState,
+			Token: finalBytes,
+		}
+
+		if err = sendSaslMessage(client, con, &saslResponseMessageToSend); err != nil {
+			klog.Errorf("failed to send sasl response message: %v", err)
+			return err
+		}
+
+		saslResponseMessage, err = receiveSaslMessage(client, con)
+		if err != nil {
+			klog.Errorf("failed to receive sasl message: %v", err)
+			return err
+		}
+	}
+
+	// SASL SUCCESS
+	if saslResponseMessage.GetState() != hadoop_common.RpcSaslProto_SUCCESS {
+		return fmt.Errorf("kerberos SASL auth failed at server side, expect 0 acutal %d", saslResponseMessage.GetState())
+	}
+
+	klog.Infof("Successfully completed Kerberos SASL negotiation")
+	return nil
+}
+
+func generateGssapiKerberosToken(krb5Config KerberosConf, spn string) ([]byte, *types.EncryptionKey, error) {
+	krb5Conf, err := config.Load(krb5Config.Krb5ConfPath)
+	if err != nil {
+		klog.Errorf("failed to load krb5 conf: %v", err)
+		return nil, nil, err
+	}
+
+	keytab, err := keytab.Load(krb5Config.KeytabPath)
+	if err != nil {
+		klog.Errorf("failed to load keytab: %v", err)
+		return nil, nil, err
+	}
+
+	kerberosClient := client.NewWithKeytab(krb5Config.ClientUserName, krb5Config.ClientRealm, keytab, krb5Conf)
+
+	if err := kerberosClient.Login(); err != nil {
+		klog.Errorf("failed to login: %v", err)
+		return nil, nil, err
+	}
+
+	targetSPN := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, spn)
+	serverTicket, sessionKey, err := kerberosClient.GetServiceTicket(targetSPN.PrincipalNameString())
+	if err != nil {
+		klog.Errorf("failed to get service ticket: %v", err)
+		return nil, nil, err
+	}
+
+	auth, err := types.NewAuthenticator(kerberosClient.Credentials.Realm(), kerberosClient.Credentials.CName())
+	if err != nil {
+		klog.Errorf("failed to get authenticator: %v", err)
+		return nil, nil, err
+	}
+	gssCksum := make([]byte, 24)
+	gssCksum[0] = 0x10
+	gssCksum[20] = 0x00
+	auth.Cksum = types.Checksum{
+		CksumType: chksumtype.GSSAPI,
+		Checksum:  gssCksum,
+	}
+
+	apReq, err := messages.NewAPReq(serverTicket, sessionKey, auth)
+	if err != nil {
+		klog.Errorf("failed to create AP_REQ: %v", err)
+		return nil, nil, err
+	}
+	apReqBytes, err := apReq.Marshal()
+	if err != nil {
+		klog.Errorf("failed to marshal AP_REQ: %v", err)
+		return nil, nil, err
+	}
+
+	// GSSAPI Encapsulation
+	oid := []byte{0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02}
+	tokenID := []byte{0x01, 0x00}
+
+	payload := append(oid, tokenID...)
+	payload = append(payload, apReqBytes...)
+
+	// 构造 Application Construct Tag (0x60)
+	var finalToken []byte
+	finalToken = append(finalToken, 0x60)
+	finalToken = append(finalToken, encodeASN1Length(len(payload))...)
+	finalToken = append(finalToken, payload...)
+
+	return finalToken, &sessionKey, nil
+}
+
+func encodeASN1Length(length int) []byte {
+	if length <= 127 {
+		return []byte{byte(length)}
+	}
+	if length <= 255 {
+		return []byte{0x81, byte(length)}
+	}
+	if length <= 65535 {
+		return []byte{0x82, byte(length >> 8), byte(length & 0xFF)}
+	}
+	return []byte{0x83, byte(length >> 16), byte(length >> 8 & 0xFF), byte(length & 0xFF)}
+}

--- a/pkg/yarn/client/ipc/kerberos_test.go
+++ b/pkg/yarn/client/ipc/kerberos_test.go
@@ -1,0 +1,62 @@
+package ipc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsEnableKerberos(t *testing.T) {
+	cases := map[string]bool{
+		"1":     true,
+		"true":  true,
+		"yes":   true,
+		"y":     true,
+		"on":    true,
+		"0":     false,
+		"false": false,
+		"no":    false,
+		"n":     false,
+		"off":   false,
+		"":      false, // default
+	}
+
+	for val, expected := range cases {
+		os.Setenv(EnvEnableKerberos, val)
+		assert.Equal(t, expected, IsEnableKerberos())
+	}
+	os.Unsetenv(EnvEnableKerberos)
+}
+
+func TestGetKerberosConf_Defaults(t *testing.T) {
+	conf := GetKerberosConf()
+	assert.Equal(t, DefaultKrb5ConfPath, conf.Krb5ConfPath)
+	assert.Equal(t, DefaultKeytabPath, conf.KeytabPath)
+	assert.Equal(t, DefaultClientUserName, conf.ClientUserName)
+	assert.Equal(t, DefaultRealm, conf.ClientRealm)
+}
+
+func TestGetKerberosConf_EnvOverride(t *testing.T) {
+	os.Setenv(EnvKrb5ConfPath, "/tmp/krb5.conf")
+	os.Setenv(EnvKeytabPath, "/tmp/test.keytab")
+	os.Setenv(EnvClientUserName, "testuser")
+	os.Setenv(EnvClientRealm, "TEST.COM")
+	conf := GetKerberosConf()
+	assert.Equal(t, "/tmp/krb5.conf", conf.Krb5ConfPath)
+	assert.Equal(t, "/tmp/test.keytab", conf.KeytabPath)
+	assert.Equal(t, "testuser", conf.ClientUserName)
+	assert.Equal(t, "TEST.COM", conf.ClientRealm)
+
+	os.Unsetenv(EnvKrb5ConfPath)
+	os.Unsetenv(EnvKeytabPath)
+	os.Unsetenv(EnvClientUserName)
+	os.Unsetenv(EnvClientRealm)
+}
+
+func TestEncodeASN1Length(t *testing.T) {
+	assert.Equal(t, []byte{0x7F}, encodeASN1Length(127))
+	assert.Equal(t, []byte{0x81, 0x80}, encodeASN1Length(128))
+	assert.Equal(t, []byte{0x82, 0x01, 0x00}, encodeASN1Length(256))
+	assert.Equal(t, []byte{0x83, 0x01, 0x00, 0x00}, encodeASN1Length(65536))
+}

--- a/pkg/yarn/client/ipc/kerberos_test.go
+++ b/pkg/yarn/client/ipc/kerberos_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Koordinator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ipc
 
 import (


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Adds Kerberos support for the YARN Resource Manager when hadoop.rpc.protection is set to authentication.

To enable Kerberos for yarn-copilot, the following environment variables must be configured. 
For example, using a keytab with the principal yarn-copilot@EXAMPLE.COM:

- name: ENABLE_KERBEROS
  value: "true"
- name: KRB5_CLIENT_USERNAME
  value: "yarn-copilot"
- name: KRB5_CLIENT_REALM
  value: "EXAMPLE.COM"
- name: KRB5_CONF_PATH
  value: "/etc/krb5.conf"
- name: KRB5_KEYTAB_PATH
  value: "/etc/security/keytabs/yarn.keytab"

Limitations:
Support for hadoop.rpc.protection levels integrity and privacy is reserved for future work, as these settings are rarely used in most environments.

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. Describe how to verify it
1. Set up a Kerberos KDC.
2. Prepare keytabs for the YARN RM, NM, and yarn-copilot.
3. Configure the YARN RM & NM to enable Kerberos and set hadoop.rpc.protection=authentication.
4. Deploy yarn-copilot with the Kerberos environment variables listed above.
5. Verify that yarn-copilot successfully updates node resources.

###  Ⅳ. Special notes for reviewers
NONE

###  V. Checklist
[x] I have written necessary docs and comments
[x] I have added necessary unit tests and integration tests
[x] All checks passed in make test